### PR TITLE
コードレビューに対応

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class Api::BaseController < ApplicationController
+class API::BaseController < ApplicationController
 end

--- a/app/controllers/api/charts_controller.rb
+++ b/app/controllers/api/charts_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::ChartsController < Api::BaseController
+class API::ChartsController < API::BaseController
   def show
     @chart = Chart.find(params[:id])
   end

--- a/app/models/chart.rb
+++ b/app/models/chart.rb
@@ -3,8 +3,7 @@
 class Chart < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  validates :title, length: { maximum: 50 }
-  validates :title, presence: true
+  validates :title, length: { in: 1..50 }
 
   def attach_blob(image_data_url)
     image_blob = ImageBlob.new(image_data_url)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   has_many :charts, dependent: :destroy
 
-  def no_password
+  def no_password?
     !!provider
   end
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,7 +16,7 @@
       <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
 
-    <% unless current_user.no_password %>
+    <% unless current_user.no_password? %>
       <div class="field">
         <%= f.label :email, class: 'label' %>
         <%= f.email_field :email, autocomplete: "email", class: 'input' %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'API'
+end


### PR DESCRIPTION
- コントローラーの名前空間に`API`を使えるよう設定
- chartモデルのバリデーションを一行にまとめた
- booleanを返すメソッド名に`?`を追加