### PR TITLE
非ログインユーザーのroot_pathを`/welcome`から`/`に変更した

### DIFF
--- a/.idea/railways.cache
+++ b/.idea/railways.cache
@@ -1,8 +1,10 @@
                                   Prefix Verb     URI Pattern                                                                                       Controller#Action
+                    unauthenticated_root GET      /                                                                                                 welcome#index
+                                 welcome GET      /welcome(.:format)                                                                                redirect(301, /)
                                     root GET      /                                                                                                 home#index
                           privacy_policy GET      /privacy_policy(.:format)                                                                         home#privacy_policy
                                      tos GET      /tos(.:format)                                                                                    home#tos
-                                 welcome GET      /welcome(.:format)                                                                                welcome#index
+                                         GET      /welcome(.:format)                                                                                welcome#index
                         new_user_session GET      /users/sign_in(.:format)                                                                          users/sessions#new
                             user_session POST     /users/sign_in(.:format)                                                                          users/sessions#create
                     destroy_user_session DELETE   /users/sign_out(.:format)                                                                         users/sessions#destroy

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,11 +2,7 @@
 
 class HomeController < ApplicationController
   def index
-    if user_signed_in?
-      redirect_to current_user
-    else
-      redirect_to welcome_path
-    end
+    redirect_to current_user
   end
 
   def privacy_policy; end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  unauthenticated :user do
+    root to: 'welcome#index', as: :unauthenticated_root
+    get 'welcome', to: redirect('/')
+  end
   root to: 'home#index'
   get 'privacy_policy', to: 'home#privacy_policy'
   get 'tos', to: 'home#tos'


### PR DESCRIPTION
closed #118
- 非ログインユーザーのroot_pathを`/welcome`から`/`に変更
- 非ログインユーザーの`/welcome`は`/`にリダイレクトに変更